### PR TITLE
fix :url property in elpa/nongnu package lists

### DIFF
--- a/lisp/elpaso-admin.el
+++ b/lisp/elpaso-admin.el
@@ -187,6 +187,19 @@ Primary entry to specs outside elpaso-disc."
                                   (not (memq fetcher '(github gitlab))))))))
                  ,lst))
 
+(defun elpaso-admin--fix-urls-in-specs (specs)
+  (mapcar
+   (lambda (spec)
+     (let* ((spec spec) ;don't know if this is necessary ...
+            (url (elpaso-admin--spec-get spec :url)))
+       (if (and url (symbolp url))
+           (let* ((ref (assoc url specs))
+                  (ref-url (and ref (elpaso-admin--spec-get ref :url))))
+             (and (stringp ref-url)
+                  (plist-put (cdr spec) :url ref-url))))
+       spec))
+   specs))
+
 (defun elpaso-admin--get-specs ()
   (interactive)
   (unless elpaso-admin--specs
@@ -217,7 +230,8 @@ Primary entry to specs outside elpaso-disc."
                                      (append new-specs
                                              (elpaso-admin--specs-filter
                                                (mapcar stringify-car
-					               (elpaso-admin-form-from-file-contents path)))))
+                                                       (elpaso-admin--fix-urls-in-specs
+                                                        (elpaso-admin-form-from-file-contents path))))))
 			     (wrong-type-argument (display-warning 'elpaso (format "elpaso-admin--get-specs: '%s' needs must 'list of lists'" (concat default-directory path)) :error)))
                          (message "elpaso-admin--get-specs: unreadable %s" path))))
                     (dir


### PR DESCRIPTION
This PR has code that fixes a problem in elpa (and nongnu) package spec data that recently caused an elpaso user (namely, me) errors during the elpaso build (make install). See the problem details here: https://github.com/commercial-emacs/elpaso/issues/3.

### Synopis
Elpa has started to put symbols in the` :url` property of some package specs in its package list. This symbol is supposed to refer to another package (an entry with that symbol as the key) in same package list. The package referred to will have a real URL (a string) in the `:url` property -- or so we hope.

There is a new utility function which will perform this lookup and replace the symbol URL with its real URL.

@dickmao I'm ok with you rejecting this PR for a better idea/solution. In the meantime, this is working for me (on my fork) so I'm pressing on with it. Thanks again for the great software!